### PR TITLE
Include heml k8s files to run the service using k8

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -6,3 +6,8 @@ app = FastAPI()
 app.include_router(libraries.router)
 app.include_router(chunks.router)
 app.include_router(vector.router)
+
+
+@app.get("/")
+def read_root():
+    return {"message": "@tonilopezmr Stack AI!"}

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -4,9 +4,10 @@ from app.vector import BruteForceVectorStore, HNSWVectorStore
 import os
 from app.storage.sql_datasource.config import initialize_postgresql
 
-POSTGRESS_DATASOURCE_OPTION = 'postgress'
+POSTGRES_DATASOURCE_OPTION = 'postgres'
 IN_MEMORY_DATASOURCE_OPTION = 'in-memory'
-DATASOURCE = os.getenv('DATASOURCE', IN_MEMORY_DATASOURCE_OPTION)  # Default to 'in-memory' if not set, options: postgress or in-memory
+DATASOURCE = os.getenv('DATASOURCE', IN_MEMORY_DATASOURCE_OPTION)  # Default to 'in-memory' if not set, options: postgres or in-memory
+print("Datasource selected: ", DATASOURCE)
 
 library_datasource = None
 chunk_datasource = None

--- a/app/storage/sql_datasource/config.py
+++ b/app/storage/sql_datasource/config.py
@@ -1,28 +1,33 @@
 from psycopg2 import pool
 import os
 
-# Create a connection pool
-connection_pool = pool.SimpleConnectionPool(
-    1,  # Minimum number of connections
-    10, # Maximum number of connections
-    dbname=os.getenv('POSTGRES_DB', 'stack_ai_database'),
-    user=os.getenv('POSTGRES_USER', 'user1'),
-    password=os.getenv('POSTGRES_PASSWORD', 'dbpassword'),
-    host=os.getenv('POSTGRES_HOST', 'localhost'),
-    port=int(os.getenv('POSTGRES_PORT', 5432))
-)
 
 def initialize_postgresql():
+    # Create a connection pool
+    connection_pool = pool.SimpleConnectionPool(
+        1,  # Minimum number of connections
+        10, # Maximum number of connections
+        dbname=os.getenv('POSTGRES_DB', 'stack_ai_database'),
+        user=os.getenv('POSTGRES_USER', 'user1'),
+        password=os.getenv('POSTGRES_PASSWORD', 'dbpassword'),
+        host=os.getenv('POSTGRES_HOST', 'localhost'),
+        port=int(os.getenv('POSTGRES_PORT', 5432))
+    )
+
     connection = connection_pool.getconn()    
 
     try:
         with connection.cursor() as cursor:
+            print("Creating tables...")
+
             cursor.execute("""
                 CREATE TABLE IF NOT EXISTS libraries (
                     id SERIAL PRIMARY KEY,
                     metadata JSONB NOT NULL
                 );
             """)
+            print("🚀 Library table created")
+
             cursor.execute("""
                 CREATE TABLE IF NOT EXISTS documents (
                     id SERIAL PRIMARY KEY,
@@ -31,6 +36,8 @@ def initialize_postgresql():
                     FOREIGN KEY (library_id) REFERENCES libraries (id) ON DELETE CASCADE
                 );
             """)
+            print("🚀 Document table created")
+
             cursor.execute("""
                 CREATE TABLE IF NOT EXISTS chunks (
                     id SERIAL PRIMARY KEY,
@@ -41,6 +48,9 @@ def initialize_postgresql():
                     FOREIGN KEY (document_id) REFERENCES documents (id) ON DELETE CASCADE
                 );
             """)
+            print("🚀 Chunk table created")
+            
+            connection.commit()
     finally:
         connection_pool.putconn(connection)
 

--- a/client.http
+++ b/client.http
@@ -1,7 +1,7 @@
 # Make manual end-to-end tests for the API client
 
 ### Create Library
-curl -X POST "http://localhost:8000/libraries/" -H "Content-Type: application/json" -d '{
+curl -X POST "http://localhost:8080/libraries/" -H "Content-Type: application/json" -d '{
   "id": 1,
   "documents": [
     {
@@ -39,7 +39,7 @@ curl -X POST "http://localhost:8000/libraries/" -H "Content-Type: application/js
 }'
 
 ### Create Library with a single document and without metadata
-curl -X POST "http://localhost:8000/libraries/" -H "Content-Type: application/json" -d '{
+curl -X POST "http://localhost:8080/libraries/" -H "Content-Type: application/json" -d '{
   "documents": [
     {
       "id": 2,
@@ -55,18 +55,18 @@ curl -X POST "http://localhost:8000/libraries/" -H "Content-Type: application/js
 }'
 
 ### Create Library with without documents
-curl -X POST "http://localhost:8000/libraries/" -H "Content-Type: application/json" -d '{
+curl -X POST "http://localhost:8080/libraries/" -H "Content-Type: application/json" -d '{
   "documents": []
 }'
 
 ### Read Library
-curl -X GET "http://localhost:8000/libraries/13"
+curl -X GET "http://localhost:8080/libraries/13"
 
 ### Read Library that doesn't exist
-curl -X GET "http://localhost:8000/libraries/100"
+curl -X GET "http://localhost:8080/libraries/100"
 
 ### Update Library
-curl -X PUT "http://localhost:8000/libraries/1" -H "Content-Type: application/json" -d '{
+curl -X PUT "http://localhost:8080/libraries/1" -H "Content-Type: application/json" -d '{
   "id": 1,
   "documents": [
     {
@@ -89,44 +89,44 @@ curl -X PUT "http://localhost:8000/libraries/1" -H "Content-Type: application/js
 
 
 ### Delete Library
-curl -X DELETE "http://localhost:8000/libraries/100"
+curl -X DELETE "http://localhost:8080/libraries/100"
 
 ### Create Chunk
-curl -X POST "http://localhost:8000/libraries/1/documents/1/chunks" -H "Content-Type: application/json" -d '{
+curl -X POST "http://localhost:8080/libraries/1/documents/1/chunks" -H "Content-Type: application/json" -d '{
   "id": 3,
   "text": "New chunk text",
   "metadata": {"author": "New Author", "date": "2024-01-04"}
 }'
 
 ### Read Chunk
-curl -X GET "http://localhost:8000/libraries/6/chunks/16"
+curl -X GET "http://localhost:8080/libraries/6/chunks/16"
 
 ### Update Chunk
-curl -X PUT "http://localhost:8000/libraries/1/chunks/3" -H "Content-Type: application/json" -d '{
+curl -X PUT "http://localhost:8080/libraries/1/chunks/3" -H "Content-Type: application/json" -d '{
   "id": 3,
   "text": "Updated chunk text",
   "metadata": {"author": "Updated Author", "date": "2024-01-05"}
 }'
 
 ### Delete Chunk
-curl -X DELETE "http://localhost:8000/libraries/1/chunks/3"
+curl -X DELETE "http://localhost:8080/libraries/1/chunks/3"
 
 ### Search Vector Similarities with Metadata Filter
-curl -X POST "http://localhost:8000/libraries/15/search_vectors" -H "Content-Type: application/json" -d '{
+curl -X POST "http://localhost:8080/libraries/15/search_vectors" -H "Content-Type: application/json" -d '{
   "vector": [0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0],
   "num_results": 2,
   "filter_metadata": {"author": "Author 1"}
 }'
 
 ### Search Vector Similarities with New Vector
-curl -X POST "http://localhost:8000/libraries/15/search_vectors" -H "Content-Type: application/json" -d '{
+curl -X POST "http://localhost:8080/libraries/15/search_vectors" -H "Content-Type: application/json" -d '{
   "vector": [0.1, 0.2, 0.3, 0.4, 0.5],
   "num_results": 2,
   "filter_metadata": {"author": "Author 1"}
 }'
 
 ### Search Vector Similarities with Metadata Filter Greater Than Specific Date
-curl -X POST "http://localhost:8000/libraries/1/search_vectors" -H "Content-Type: application/json" -d '{
+curl -X POST "http://localhost:8080/libraries/1/search_vectors" -H "Content-Type: application/json" -d '{
   "vector": [0.13, 0.23, 0.43, 0.43, 0.13],
   "num_results": 2,
   "filter_metadata": {"date": {"$gt": "2024-01-01"}}

--- a/stack-ai/.helmignore
+++ b/stack-ai/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/stack-ai/Chart.yaml
+++ b/stack-ai/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: stack-ai
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/stack-ai/templates/NOTES.txt
+++ b/stack-ai/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "stack-ai.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch its status by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "stack-ai.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "stack-ai.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "stack-ai.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/stack-ai/templates/_helpers.tpl
+++ b/stack-ai/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "stack-ai.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "stack-ai.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "stack-ai.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "stack-ai.labels" -}}
+helm.sh/chart: {{ include "stack-ai.chart" . }}
+{{ include "stack-ai.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "stack-ai.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "stack-ai.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "stack-ai.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "stack-ai.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/stack-ai/templates/deployment.yaml
+++ b/stack-ai/templates/deployment.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "stack-ai.fullname" . }}
+  labels:
+    {{- include "stack-ai.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "stack-ai.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "stack-ai.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: 5000
+          env:
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-secret
+                  key: POSTGRES_DB
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-secret
+                  key: POSTGRES_USER
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-secret
+                  key: POSTGRES_PASSWORD
+            - name: POSTGRES_HOST
+              value: "postgresql"
+            - name: POSTGRES_PORT
+              value: "5432"
+            - name: DATASOURCE
+              value: "postgres"

--- a/stack-ai/templates/hpa.yaml
+++ b/stack-ai/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "stack-ai.fullname" . }}
+  labels:
+    {{- include "stack-ai.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "stack-ai.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/stack-ai/templates/ingress.yaml
+++ b/stack-ai/templates/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "stack-ai.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "stack-ai.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/stack-ai/templates/postgresql-pv-pvc.yaml
+++ b/stack-ai/templates/postgresql-pv-pvc.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: postgredb-pv
+  labels:
+    type: local
+spec:
+  storageClassName: manual
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: "/mnt/data"
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgredb-pvc
+spec:
+  storageClassName: manual
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/stack-ai/templates/postgresql.yaml
+++ b/stack-ai/templates/postgresql.yaml
@@ -1,0 +1,55 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgresql
+  labels:
+    app: postgresql
+spec:
+  ports:
+    - port: 5432
+  selector:
+    app: postgresql
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgresql
+spec:
+  selector:
+    matchLabels:
+      app: postgresql
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: postgresql
+    spec:
+      containers:
+      - name: postgresql
+        image: postgres:14.7
+        ports:
+        - containerPort: 5432
+        env:
+        - name: POSTGRES_DB
+          valueFrom:
+            secretKeyRef:
+              name: postgres-secret
+              key: POSTGRES_DB
+        - name: POSTGRES_USER
+          valueFrom:
+            secretKeyRef:
+              name: postgres-secret
+              key: POSTGRES_USER
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: postgres-secret
+              key: POSTGRES_PASSWORD
+        volumeMounts:
+        - name: postgredb
+          mountPath: /var/lib/postgresql/data
+      volumes:
+      - name: postgredb
+        persistentVolumeClaim:
+          claimName: postgredb-pvc

--- a/stack-ai/templates/service.yaml
+++ b/stack-ai/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "stack-ai.fullname" . }}
+  labels:
+    {{- include "stack-ai.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
+      nodePort: {{ .Values.service.nodePort }}
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "stack-ai.selectorLabels" . | nindent 4 }}

--- a/stack-ai/templates/serviceaccount.yaml
+++ b/stack-ai/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "stack-ai.serviceAccountName" . }}
+  labels:
+    {{- include "stack-ai.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/stack-ai/templates/tests/test-connection.yaml
+++ b/stack-ai/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "stack-ai.fullname" . }}-test-connection"
+  labels:
+    {{- include "stack-ai.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "stack-ai.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/stack-ai/values.yaml
+++ b/stack-ai/values.yaml
@@ -1,0 +1,108 @@
+replicaCount: 1
+
+image:
+  repository: stack-ai
+  pullPolicy: IfNotPresent  
+  tag: "latest.2"
+
+postgresql:
+  image: postgres:14.7
+  database: stack_ai_database
+  user: user1
+  password: dbpassword
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 5000
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+livenessProbe:
+  httpGet:
+    path: /
+    port: http
+readinessProbe:
+  httpGet:
+    path: /
+    port: http
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+# Additional volumes on the output Deployment definition.
+volumes: []
+# - name: foo
+#   secret:
+#     secretName: mysecret
+#     optional: false
+
+# Additional volumeMounts on the output Deployment definition.
+volumeMounts: []
+# - name: foo
+#   mountPath: "/etc/foo"
+#   readOnly: true
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
* Included [helm project](https://helm.sh/) package manager for kubernetes 
* Adds PostgreSQL database service
* Adds Python Fast API service

### Tools used and installation

[helm project](https://helm.sh/) package manager for kubernetes 

```
brew install helm
```

Install [minikube](https://minikube.sigs.k8s.io/docs/start/?arch=%2Fmacos%2Farm64%2Fstable%2Fbinary+download)

```
curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-darwin-arm64
sudo install minikube-darwin-arm64 /usr/local/bin/minikube
```

When you install minikube it installs kubectl, if not here [are the instructions to install it](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/)

### Setup

1. First you need to build the docker image:

```
docker build -t stack-ai:latest .
```

2. Include it in minikube to make sure It will be reachable on localhost:

```
minikube image load stack-ai:latest.2
```

3. Start the pods using helm:

You have to know that `stack-ai` folder is the `heml` project with the k8s files.

```
helm install stack-ai ./stack-ai
```

4. Port-forward to your localhost

I didn't have time to do it using a `LoadBalancer` to make it reachable externally.

```
POD_NAME=$(kubectl get pods --namespace default -l "app.kubernetes.io/name=stack-ai,app.kubernetes.io/instance=stack-ai" -o jsonpath="{.items[0].metadata.name}")
kubectl --namespace default port-forward $POD_NAME 8080:5000
```

You can use `client.http` file with the REST Client VSCode extension: `humao.rest-client`


